### PR TITLE
Remove agent_git from tools list

### DIFF
--- a/.github/workflows/genai-pr-description.yml
+++ b/.github/workflows/genai-pr-description.yml
@@ -10,7 +10,7 @@ permissions:
     pull-requests: write # permission to write a comment
     models: read # permission to use github models
 jobs:
-    review:
+    describe:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/genaisrc/prd.genai.mts
+++ b/genaisrc/prd.genai.mts
@@ -2,7 +2,7 @@ script({
     title: "Pull Request Descriptor",
     description: "Generate a description for the current pull request",
     systemSafety: true,
-    tools: ["agent_fs", "agent_git"],
+    tools: ["agent_fs"],
     parameters: {
         base: "",
     },

--- a/genaisrc/prr.genai.mts
+++ b/genaisrc/prr.genai.mts
@@ -2,7 +2,7 @@ script({
     title: "Pull Request Reviewer",
     description: "Review the current pull request",
     systemSafety: true,
-    tools: ["agent_fs", "agent_git"],
+    tools: ["agent_fs"],
     parameters: {
         base: ""
     }


### PR DESCRIPTION
Eliminate the use of `agent_git` in the pull request descriptor and reviewer scripts to streamline the tools utilized.

<!-- genaiscript begin prd --><hr/>

- 🔒 Removed agent_git tool from both "Pull Request Descriptor" and "Pull Request Reviewer" scripts, leaving only the agent_fs tool enabled
- 🛡️ Maintained systemSafety and general parameter structure unchanged in both scripts
- 🧹 Simplified tool usage to reduce dependencies on git-specific operations

> AI-generated content by [prd](https://github.com/pelikhan/genaiscript-actions/actions/runs/14874456206) may be incorrect. Use reactions to eval.



<!-- genaiscript end prd -->

